### PR TITLE
Fix bundle install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'http://rubygems.org'
 gem 'httparty'
 
 group :development do
-  gem 'bundler', '1.10.5'
+  gem 'bundler'
   gem 'jeweler', '~> 1.8.4'
   gem 'simplecov', require: false
   gem 'reek', '~> 1.2.8'


### PR DESCRIPTION
Found that we don't need to specify the version of gem and it was causing `bundle install` to break